### PR TITLE
MDViewer 사용 및 정규 표현식으로 헤더 추출

### DIFF
--- a/src/components/Details/DetailHeader.tsx
+++ b/src/components/Details/DetailHeader.tsx
@@ -9,6 +9,7 @@ import { userInfo } from "../../types/Main";
 import { PostContext } from "@pages/[id]/[details]";
 import { useContext, useEffect, useState } from "react";
 import { SeriesBoxPost } from "@src/types/Detail";
+import { MDviewer } from "../Editor/EditorViewer";
 
 interface Props {
   userName: string | string[] | undefined;
@@ -127,7 +128,7 @@ export const DetailHeader = ({
         SeriesBoxPost={seriesData.post.data}
         currentPost={currentPost}
       />
-      <div>{postObj.contents}</div>
+      <MDviewer title="" contents={postObj.contents} />
       <div ref={setTarget}></div>
       <Intro username={userName} userdata={userdata} />
       <Carousel

--- a/src/components/Details/RightHeader.tsx
+++ b/src/components/Details/RightHeader.tsx
@@ -1,22 +1,35 @@
 import styled from "@emotion/styled";
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { PALLETS_LIGHT } from "@constants/index";
 import Link from "next/link";
+import { PostContext } from "@src/pages/[id]/[details]";
+
+interface StrNum {
+  strNum: number;
+}
 
 export const RightHeader = () => {
-  const [listData, setListData] = useState(["프로젝트 설계 시작", "역할"]);
+  const { postObj } = useContext(PostContext);
+  const [listData, setListData] = useState(postObj.contents.match(/#+ .*/g)!);
+  // const Scrollref = useRef<HTMLDivElement>(null);
+
+  // const onClickList = () => {
+  //   Scrollref.current?.scrollIntoView({ behavior: "smooth" });
+  // };
+
   return (
     <Container>
       <h2 className="sr-only">목차</h2>
-      {listData.length === 0 ? (
-        <div></div>
-      ) : (
+      {listData.length !== 0 && (
         <article>
-          {listData.map((str) => {
+          {listData.map((str, i) => {
+            const strNum = str.match(/#*/)?.join("").length!;
+            const strReg = str.match(/[^#+][#]*/g)?.join("");
+
             return (
-              <Link key={`Detail-List-${str}`} href="#">
+              <Link key={`Detail-List-${i}`} href="#">
                 <a>
-                  <List>{str}</List>
+                  <List strNum={strNum}>{strReg}</List>
                 </a>
               </Link>
             );
@@ -34,7 +47,6 @@ const Container = styled.section`
   height: 100%;
 
   article {
-    /* width: 130px; */
     padding: 8px 10px;
     border-left: 2px solid ${PALLETS_LIGHT.SUB};
     margin-left: 40px;
@@ -46,10 +58,11 @@ const Container = styled.section`
     display: none;
   }
 `;
-const List = styled.div`
+const List = styled.div<StrNum>`
   font-size: 14px;
   color: ${PALLETS_LIGHT.ICON};
   margin-bottom: 5px;
+  margin-left: ${({ strNum }) => strNum * 10}px;
   &:hover {
     color: ${PALLETS_LIGHT.SUB_FONT};
   }


### PR DESCRIPTION
## 세부 사항
- 상세 페이지 내용 부분에서 MDViewer 컴포넌트를 사용하고 있습니다.
- 정규 표현식으로 #을 포함한 헤더를 추출했습니다.
- UI에서 헤더 기능으로 사용되는 #을 제거되고, 들여쓰기 됩니다.

## 기타 질문 및 특이 사항
- 스크롤 위치에 따라 목차의 한 부분의 글씨가 진해져야 하며, 클릭시 이동도 가능해야 합니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
