### PR TITLE
포스트 썸네일 없을 경우 레이아웃 설정, 메인페이지 메뉴옵션 수정

### DIFF
--- a/src/components/Home/ListCard.tsx
+++ b/src/components/Home/ListCard.tsx
@@ -33,38 +33,32 @@ export const ListCard = ({
 } : Cardprops) => {
   const { theme } = useContext(ThemeContext);
 
-  const handleThumbnailError = (
-    event: React.SyntheticEvent<HTMLImageElement, Event>
-  ) => {
-    event.currentTarget.src = '/image/default_thumbnail.png';
-    event.currentTarget.style.transform = "scale(0.8)";
-  };
-
   const handleAuthorImgError = (
     event: React.SyntheticEvent<HTMLImageElement, Event>
   ) => {
-    event.currentTarget.src = '/image/junghoon_memoji.png';
+    event.currentTarget.src = '/image/sampleUser.g';
     event.currentTarget.style.transform = "scale(1.2)";
   };
 
   return (
     <Card theme={theme}>
-      <Link href={`/${username}/${url}`} passHref>
-        <a>
-          <ThumbnailWrap>
-            <Thumbnail src={''} alt="" onError={handleThumbnailError}/>
-          </ThumbnailWrap>
-          <Post theme={theme}>
+      <PostSection>
+        <Link href={`/${username}/${url}`} passHref>
+          <a>
+            {thumbnail &&
+            (<ThumbnailWrap theme={theme}>
+              <Thumbnail src={''} alt=""/>
+            </ThumbnailWrap>)}
             <PostTitle theme={theme}>{title}</PostTitle>
             <PostContent theme={theme}>{contents}</PostContent>
-            <div>
-              <PostDesc theme={theme}>{handleDate(publishedAt)}</PostDesc>
-              <Dot>&#183;</Dot>
-              <PostDesc theme={theme}>{comments || 0}개의 댓글</PostDesc>
-            </div>
-          </Post>
-        </a>
-      </Link>
+          </a>
+        </Link>
+        <div>
+            <PostDesc theme={theme}>{handleDate(publishedAt)}</PostDesc>
+            <Dot>&#183;</Dot>
+            <PostDesc theme={theme}>{comments || 0}개의 댓글</PostDesc>
+        </div>
+      </PostSection>
       <AuthorDesc theme={theme}>
         <Link href={`/${username}`} passHref>
           <Author theme={theme}>
@@ -105,11 +99,12 @@ const Card = styled.article<ThemeProps>`
   }
 `;
 
-const Post = styled.section<ThemeProps>`
-  overflow: hidden;
+const PostSection = styled.section`
+  padding: 16px;
   display: flex;
   flex-direction: column;
-  padding: 16px;
+  flex: 1 1 0%;
+  overflow: hidden;
 `;
 
 const PostTitle = styled.h4<ThemeProps>`
@@ -142,10 +137,10 @@ const PostDesc = styled.span<ThemeProps>`
   font-size: 12px;
 `;
 
-const ThumbnailWrap= styled.section`
+const ThumbnailWrap = styled.section<ThemeProps>`
   position: relative;
   padding-top: 52%;
-  background: white;
+  background: ${({ theme }) => theme.CARD_BACKGROUND};
 `;
 
 const Thumbnail = styled.img`

--- a/src/components/Home/Notice.tsx
+++ b/src/components/Home/Notice.tsx
@@ -17,7 +17,7 @@ const OPTIONS = [
   { key: 'notice', value: 'notice', link: '/@sdv', name: '공지사항' },
   { key: 'tag', value: 'tag', link: '/tags', name: '태그 목록' },
   { key: 'policy', value: 'policy', link: '/policy', name: '서비스 정책' },
-  { key: 'slack', value: 'slack', link: '/slack', name: 'Slack' },
+  { key: 'EasterEgg', value: 'EasterEgg', link: '/introduce', name: 'easter egg' },
 ];
 
 export const Notice = ({ route }: { route: string }) => {
@@ -35,14 +35,18 @@ export const Notice = ({ route }: { route: string }) => {
           const { key, value, name, link } = option;
           return (
             <List theme={theme} key={key} value={value}>
-              <Link href={link}>
-                <a>{name}</a>
+              <Link href={link} passHref>
+                <Anchor theme={theme}>{name}</Anchor>
               </Link>
             </List>
           );
         })}
         <List theme={theme}>
-          문의 <p>jhp@sdv.io</p>
+          <Link href={"mailto:spacedevclub@gmail.com"} passHref>
+            <Anchor theme={theme}>
+              문의 <AnchorDesc>spacedevclub@gmail.com</AnchorDesc>
+            </Anchor>
+          </Link>
         </List>
       </Box>
     </Container>
@@ -78,23 +82,27 @@ const List = styled.li<ThemeProps>`
   list-style: none;
   font-weight: 600;
   font-size: 14px;
-  padding: 12px 16px;
   cursor: pointer;
   line-height: none;
   color: ${({ theme }) => theme.MAIN_FONT};
 
-  a {
-    color: ${({ theme }) => theme.MAIN_FONT};
-  }
-
   & + & {
     border-top: 1px solid ${({ theme }) => theme.POINT_FONT};
   }
+
   &:last-child {
     font-size: 12px;
   }
-  p {
-    font-weight: 400;
-    font-size: 12px;
-  }
 `;
+
+const Anchor = styled.a<ThemeProps>`
+  display:block;
+  color: ${({ theme }) => theme.MAIN_FONT};
+  padding: 12px 16px; 
+`;
+
+const AnchorDesc = styled.p`
+  font-weight: 400;
+  font-size: 12px;
+`;
+


### PR DESCRIPTION
## 세부 사항
- 포스트 썸네일 없을 경우 레이아웃 설정
     - 포스트 썸네일 없을 경우 기본 이미지를 제공하지 않고, 제목과 소개글만 보여집니다.
     - 한 줄의 포스트 모두 썸네일이 없을 경우, row height가 줄어듭니다.
     - 한 줄의 일부 포스트만 썸네일이 없을 경우, row height는 유지됩니다.
<img width="1058" alt="image" src="https://user-images.githubusercontent.com/93420227/157836049-b66fd7fb-d047-4fcc-866e-96c082810cf8.png">

- 메인페이지 메뉴 옵션 수정
     - slack을 easter egg로 수정했습니다
     - 메일 주소를 'spacedevclub@gmail.com'으로 수정했습니다.
<img width="242" alt="image" src="https://user-images.githubusercontent.com/93420227/157839724-054fcaba-500b-4b4c-8c6f-0b8586ecc1c9.png">

- 유저 이미지 없을 경우, 기본 이미지 루피로 바꿔놨습니다.

## 기타 질문 및 특이 사항
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
